### PR TITLE
update users list per page

### DIFF
--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -12,6 +12,6 @@ class UserService
         return User::query()
             ->with(['roles'])
             ->latest()
-            ->paginate(2);
+            ->paginate(20);
     }
 }


### PR DESCRIPTION
### Summary
This pull request updates the pagination limit for the list method in the UserService from 2 users per page to 20 users per page.

### Changes

1. Update Pagination Limit in UserService: The list method in the UserService has been updated to return 20 users per page instead of the previous limit of 2 users per page. This change was made in the paginate method call within the list method.

### Impact
This change will allow for a more efficient browsing experience when viewing the list of users. Instead of having to navigate through many pages when there are more than a few users, users of the application will now be able to see up to 20 users on a single page.

### Next Steps
After merging this pull request, the next steps will be to verify that the updated pagination limit is working as expected in the application's UI. Future work may include making the pagination limit configurable so that it can be easily adjusted based on the needs of the application.