### PR TITLE
 add page size option on get users list API

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Enums\PermissionEnum;
+use App\Http\Requests\GetUserRequest;
 use App\Http\Requests\UserRequest;
 use App\Http\Resources\UserResource;
 use App\Models\User;
@@ -20,10 +21,10 @@ class UserController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index(): JsonResponse
+    public function index(GetUserRequest $request): JsonResponse
     {
         $this->authorize(PermissionEnum::CAN_READ_USERS->value, User::class);
-        $user = $this->userService->list();
+        $user = $this->userService->list($request->per_page ?? 20);
 
         return UserResource::collection($user)
             ->response();

--- a/app/Http/Requests/GetUserRequest.php
+++ b/app/Http/Requests/GetUserRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class GetUserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'per_page' => 'integer',
+        ];
+    }
+}

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -7,11 +7,11 @@ use Illuminate\Pagination\LengthAwarePaginator;
 
 class UserService
 {
-    public function list(): LengthAwarePaginator
+    public function list(int $perPage = 20): LengthAwarePaginator
     {
         return User::query()
             ->with(['roles'])
             ->latest()
-            ->paginate(20);
+            ->paginate($perPage);
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -32,8 +32,12 @@ class UserFactory extends Factory
         // ];
 
         return [
-            'name' => "admin",
-            'email' => "admin@admin.com",
+            'first_name' => fake()->firstName(),
+            'middle_name' => fake()->lastName(),
+            'last_name' => fake()->lastName(),
+            'description' => fake()->sentence(),
+            'contact' => fake()->phoneNumber(),
+            'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),

--- a/database/seeders/TestUserSeeder.php
+++ b/database/seeders/TestUserSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\RoleEnum;
+use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class TestUserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $users = User::factory()->count(20)->create();
+        foreach ($users as $user) {
+            $user->syncRoles([RoleEnum::STUDENT->value, RoleEnum::LEVEL_TWO_OFFICER->value]);
+        }
+    }
+}


### PR DESCRIPTION
### Summary
This pull request introduces a new feature that allows clients to specify the page size when requesting a list of users from the API.

### Changes

- **Add Page Size Option in Get Users API**: The `index` method in the `UserController` has been updated to accept a `per_page` parameter from the request. This parameter is used to determine the number of users to return per page when listing users. If the `per_page` parameter is not provided, the API will default to returning 20 users per page.

### Impact
This change will provide more flexibility to clients when requesting a list of users. Clients can now specify the number of users they want to receive per page, allowing them to better control the amount of data they receive and how they paginate through the users.